### PR TITLE
Force PyDMD precompilation before running pytest

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,4 +3,6 @@ from svdrom._pydmd_compat import precompile_pydmd
 
 def pytest_configure() -> None:
     """Precompile PyDMD before pytest imports it with warnings promoted to errors."""
-    precompile_pydmd()
+    # this is necessary to avoid SyntaxWarnings from PyDMD raising errors during
+    # pytest runs
+    precompile_pydmd(force=True)


### PR DESCRIPTION
Turns out PyDMD precompilation must be forced before running pytest. I believe the reason is that the SyntaxWarning from PyDMD occurs at compile-time, before pytest applies the filter `filterwarnings=["error"]`, and hence before `precompile_pydmd()` can tell if syntax warnings have been promoted to errors.