### PR TITLE
Ensure `n_modes` is capped by theoretical max matrix rank in POD class

### DIFF
--- a/src/svdrom/pod.py
+++ b/src/svdrom/pod.py
@@ -10,6 +10,69 @@ logger = setup_logger("POD", "pod.log")
 
 
 class POD(TruncatedSVD):
+    """Proper Orthogonal Decomposition (POD) of a spatio-temporal field.
+
+    POD decomposes a spatio-temporal snapshot matrix X (space x time)
+    into a set of orthonormal spatial modes, an energy (eigenvalue)
+    associated with each mode, and time coefficients describing how
+    each mode evolves in time:
+
+        X'(x, t) ~= sum_j phi_j(x) * a_j(t)
+
+    where X' is the (optionally mean-removed) fluctuating field, phi_j
+    are the POD spatial modes, and a_j are the corresponding time
+    coefficients. Internally this is computed via a truncated SVD of
+    X' (scaled by 1/sqrt(n_snapshots) so that modal energy does not
+    depend on the number of snapshots), inheriting the SVD backend
+    and lazy/eager compute behaviour from `TruncatedSVD`.
+
+    Parameters
+    ----------
+    n_modes: int
+        Number of POD modes to compute. Must be less than
+        min(n_spatial_points, n_snapshots).
+    svd_algorithm: str, {'tsqr', 'randomized'}, (default 'tsqr')
+        SVD algorithm used as the backend. See `TruncatedSVD` for
+        details on the trade-offs between the two algorithms.
+    compute_modes: bool, (default True)
+        Whether to eagerly compute the POD spatial modes. If False,
+        `modes` is returned as a lazy Dask collection until
+        `compute_modes()` is called.
+    compute_time_coeffs: bool, (default True)
+        Whether to eagerly compute the POD time coefficients. If
+        False, `time_coeffs` is returned as a lazy Dask collection
+        until `compute_time_coeffs()` is called.
+    compute_energy_ratio: bool, (default False)
+        Whether to eagerly compute the ratio of total energy
+        explained by each mode. If False, `explained_energy_ratio`
+        is returned as a lazy Dask collection until
+        `compute_energy_ratio()` is called.
+    rechunk: bool, (default False)
+        If using the 'randomized' algorithm, whether to rechunk the
+        input array to ensure a single chunk along the smallest
+        dimension. See `TruncatedSVD` for more details.
+    remove_mean: bool, (default True)
+        Whether to remove the temporal mean from the input array
+        before computing the POD modes. The mean is stored and
+        added back automatically in `reconstruct()`, and subtracted
+        automatically in `transform()`.
+    time_dimension: str, (default 'time')
+        Name of the dimension in the input array that represents
+        time. The input array is transposed automatically if this
+        dimension is not already along the columns.
+
+    Attributes
+    ----------
+    modes: xr.DataArray or None
+        POD spatial modes, shape (n_spatial_points, n_modes).
+    time_coeffs: xr.DataArray or None
+        Time coefficients, shape (n_modes, n_snapshots).
+    energy: np.ndarray or None
+        Energy (variance) explained by each POD mode.
+    explained_energy_ratio: np.ndarray or da.Array or None
+        Ratio of total energy explained by each POD mode.
+    """
+
     def __init__(
         self,
         n_modes: int,

--- a/src/svdrom/pod.py
+++ b/src/svdrom/pod.py
@@ -169,8 +169,8 @@ class POD(TruncatedSVD):
         max_components = min(n_spatial_points, n_snapshots)
         if self._n_components >= max_components:
             msg = (
-                "n_components must be less than min(n_spatial_points, "
-                f"n_snapshots). Got n_components: {self.n_components}, "
+                "n_modes must be less than min(n_spatial_points, "
+                f"n_snapshots). Got n_modes: {self.n_components}, "
                 f"n_spatial_points: {n_spatial_points}, n_snapshots: {n_snapshots}."
             )
             logger.error(msg)

--- a/src/svdrom/pod.py
+++ b/src/svdrom/pod.py
@@ -99,6 +99,20 @@ class POD(TruncatedSVD):
                 "is not a dimension of the input array."
             )
             raise ValueError(msg)
+
+        n_snapshots = X.sizes[self._time_dim]
+        space_dim = next(d for d in X.dims if d != self._time_dim)
+        n_spatial_points = X.sizes[space_dim]
+        max_components = min(n_spatial_points, n_snapshots)
+        if self._n_components >= max_components:
+            msg = (
+                "n_components must be less than min(n_spatial_points, "
+                f"n_snapshots). Got n_components: {self.n_components}, "
+                f"n_spatial_points: {n_spatial_points}, n_snapshots: {n_snapshots}."
+            )
+            logger.error(msg)
+            raise ValueError(msg)
+
         X = self._preprocess_array(X)
         super().fit(X, **kwargs)
         assert isinstance(self._s, np.ndarray)

--- a/tests/test_pod.py
+++ b/tests/test_pod.py
@@ -253,6 +253,23 @@ def test_invalid_time_dimension_error():
 
 
 @pytest.mark.parametrize("matrix_type", ["tall-and-skinny", "short-and-fat"])
+def test_n_modes_exceeds_max_rank_error(matrix_type):
+    """Test that a ValueError is raised when n_modes is at least
+    min(n_spatial_points, n_snapshots), the maximum possible rank."""
+    X = make_dataarray(matrix_type)
+    n_space, n_time = X.shape
+    max_components = min(n_space, n_time)
+
+    pod = POD(n_modes=max_components)
+    with pytest.raises(ValueError, match="min\\(n_spatial_points, n_snapshots\\)"):
+        pod.fit(X)
+
+    # One less than the max rank should be accepted.
+    pod = POD(n_modes=max_components - 1)
+    pod.fit(X)
+
+
+@pytest.mark.parametrize("matrix_type", ["tall-and-skinny", "short-and-fat"])
 def test_transform(matrix_type):
     """Test the transform method projects data onto POD modes correctly."""
     X = make_dataarray(matrix_type)


### PR DESCRIPTION
This PR enforces a validation check on the POD fit so that the user cannot request a number of modes greater than or equal to `min(n_space, n_snapshots)`, which is the theoretical maximum rank of the input matrix `X`. It also adds a docstring to the POD class, which was missing one.