### PR TITLE
Use Read the Docs native uv install method

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,12 +7,13 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.12"  # must satisfy requires-python in pyproject.toml
-  jobs:
-    create_environment:
-      - python -m pip install uv
-      - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
-    install:
-      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --extra docs
+
+python:
+  install:
+    - method: uv
+      command: sync
+      extras:
+        - docs
 
 sphinx:
   configuration: source/conf.py


### PR DESCRIPTION
The create_environment job installed uv with `python -m pip install uv`, which places the console script in the asdf-managed Python's `bin/` without creating an asdf shim. Subsequent commands resolve through the shims dir, so the build failed with `/bin/sh: 1: uv: not found`.

Replace the build.jobs workaround with `python.install` / `method: uv`, which lets Read the Docs provision the environment and invoke `uv sync` itself, dropping the manual `uv venv` and UV_PROJECT_ENVIRONMENT export.
Uses `extras: [docs]` since docs lives in project.optional-dependencies rather than a PEP 735 dependency group.